### PR TITLE
feat: bump version and update readme to include build step when publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ We build Figment Elements to help you integrate staking in a matter of minutes, 
 
 Make changes, and build with `pnpm build`. Then, link the package in your project using your chosen package manager to test the changes.
 
-To publish, make sure to bump the version in the `package.json` and then commit and push your changes. Once that's done, run:
+To publish, first run `pnpm build` to build the dist files, then make sure to bump the version in the `package.json` and then commit and push your changes. Once that's done, run:
 
 ```bash
 npm publish --access public

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@figmentio/elements",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Install and import Figment Elements directly to your project to gain access to Figment's functionality, such as staking.",
   "type": "module",
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
The 1.3.1 release didn't include any JS - I realized you have to build the package before publishing it.  

I've already released version 1.3.2, and updated the readme to include this important step.