### PR TITLE
feat: add separate types for babylon and solana custom wallets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@figmentio/elements",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Install and import Figment Elements directly to your project to gain access to Figment's functionality, such as staking.",
   "type": "module",
   "main": "dist/index.cjs.js",

--- a/src/elements/types.ts
+++ b/src/elements/types.ts
@@ -19,9 +19,15 @@ enum SolanaNetwork {
   devnet = "devnet",
 }
 
-export type CustomWalletConfig = {
+export type BabylonCustomWalletConfig = {
   address: string;
   publicKey: string;
+  signTransaction: (transaction: string) => Promise<string>;
+  signMessage: (message: string) => Promise<string>;
+};
+
+export type SolanaCustomWalletConfig = {
+  address: string;
   signTransaction: (transaction: string) => Promise<string>;
   signMessage: (message: string) => Promise<string>;
 };
@@ -38,22 +44,22 @@ type BaseStakingProps = {
   isTestnetMode?: boolean;
 };
 
-type StakingPropsWithWalletEthereum = BaseStakingProps & {
-  protocol: "ethereum";
-  network: ProtocolToNetworkMap[Protocol.ethereum];
-  wallet: CustomWalletConfig;
-};
+// type StakingPropsWithWalletEthereum = BaseStakingProps & {
+//   protocol: "ethereum";
+//   network: ProtocolToNetworkMap[Protocol.ethereum];
+//   wallet: CustomWalletConfig;
+// };
 
 type StakingPropsWithWalletBabylon = BaseStakingProps & {
   protocol: "babylon";
   network: ProtocolToNetworkMap[Protocol.babylon];
-  wallet: CustomWalletConfig;
+  wallet: BabylonCustomWalletConfig;
 };
 
 type StakingPropsWithWalletSolana = BaseStakingProps & {
   protocol: "solana";
   network: ProtocolToNetworkMap[Protocol.solana];
-  wallet: CustomWalletConfig;
+  wallet: SolanaCustomWalletConfig;
 };
 
 type StakingPropsWithoutWalletEthereum = BaseStakingProps & {
@@ -75,7 +81,8 @@ type StakingPropsWithoutWalletSolana = BaseStakingProps & {
 };
 
 export type StakingProps =
-  | StakingPropsWithWalletEthereum
+  // Once we enable custom wallets for Ethereum, we can uncomment this
+  // | StakingPropsWithWalletEthereum
   | StakingPropsWithWalletBabylon
   | StakingPropsWithWalletSolana
   | StakingPropsWithoutWalletEthereum


### PR DESCRIPTION
We don't need a `publicKey` in the SOL custom wallet config, so updating types accordingly.