### PR TITLE
fix: es and type exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@figmentio/elements",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Install and import Figment Elements directly to your project to gain access to Figment's functionality, such as staking.",
   "type": "module",
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.es.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,7 +17,7 @@ export default [
         sourcemap: true,
       },
       {
-        file: "dist/index.es.js",
+        file: "dist/index.mjs",
         format: "es",
         exports: "named",
         sourcemap: true,

--- a/src/elements/staking.tsx
+++ b/src/elements/staking.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useRef } from "react";
 import { style } from "./style";
-import { PostMessageType, StakingProps } from "./types";
+import {
+  BabylonCustomWalletConfig,
+  PostMessageType,
+  StakingProps,
+} from "./types";
 
 const Staking: React.FC<StakingProps> = ({
   protocol = "ethereum",
@@ -88,8 +92,12 @@ const Staking: React.FC<StakingProps> = ({
   const iframeWalletConfig = wallet
     ? JSON.stringify({
         address: wallet.address,
-        publicKey: wallet.publicKey,
         network,
+        ...(protocol === "babylon"
+          ? {
+              publicKey: (wallet as BabylonCustomWalletConfig).publicKey,
+            }
+          : {}),
       })
     : undefined;
 

--- a/src/elements/types.ts
+++ b/src/elements/types.ts
@@ -38,6 +38,11 @@ type ProtocolToNetworkMap = {
   [Protocol.solana]: keyof typeof SolanaNetwork;
 };
 
+export type ProtocolToWalletConfigMap = {
+  [Protocol.babylon]: BabylonCustomWalletConfig;
+  [Protocol.solana]: SolanaCustomWalletConfig;
+};
+
 type BaseStakingProps = {
   appId: string;
   protocol: keyof typeof Protocol;
@@ -53,13 +58,13 @@ type BaseStakingProps = {
 type StakingPropsWithWalletBabylon = BaseStakingProps & {
   protocol: "babylon";
   network: ProtocolToNetworkMap[Protocol.babylon];
-  wallet: BabylonCustomWalletConfig;
+  wallet: ProtocolToWalletConfigMap[Protocol.babylon];
 };
 
 type StakingPropsWithWalletSolana = BaseStakingProps & {
   protocol: "solana";
   network: ProtocolToNetworkMap[Protocol.solana];
-  wallet: SolanaCustomWalletConfig;
+  wallet: ProtocolToWalletConfigMap[Protocol.solana];
 };
 
 type StakingPropsWithoutWalletEthereum = BaseStakingProps & {


### PR DESCRIPTION
Versions 1.3.1 / 1.3.2 introduced a different file extension for our built files. However, we didn't update the demo app from 1.3.0 until now, and it looks like the demo app doesn't like this new way of generating the files. To get the widget to render we have to do this:

```
import { Staking } from "@figmentio/elements/dist/index.es";
```

But even with doing that, we still get this build error: https://vercel.com/figmentio/elements/nTXQW6SdkD7GAiccCFE5TZt8xYEB?filter=errors

So, changing some file extensions and adding a declaration for types so that they're more easily found by consumers.