### PR TITLE
fix(deps): add picomatch overrides to fix ReDoS and method injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,12 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "pnpm": {
+    "overrides": {
+      "picomatch@<2.3.2": "2.3.2",
+      "picomatch@>=4.0.0 <4.0.4": "4.0.4"
+    }
+  },
   "devDependencies": {
     "@babel/core": "~7.24.7",
     "@babel/preset-react": "~7.24.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  picomatch@<2.3.2: 2.3.2
+  picomatch@>=4.0.0 <4.0.4: 4.0.4
+
 importers:
 
   .:
@@ -1058,12 +1062,12 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pify@4.0.1:
@@ -1734,7 +1738,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       rollup: 4.59.0
 
@@ -2277,7 +2281,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
@@ -2348,9 +2352,9 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   pify@4.0.1: {}
 


### PR DESCRIPTION
## Summary

- Adds \`pnpm.overrides\` for \`picomatch\` in the \`2.x\` and \`4.x\` lines to fix ReDoS vulnerability via extglob quantifiers and method injection via POSIX character classes

## Vulnerabilities fixed

| CVE/GHSA | Description | Severity | Alert |
|----------|-------------|----------|-------|
| picomatch ReDoS via extglob | picomatch 2.x | High | #75, #80 |
| picomatch method injection via POSIX char classes | picomatch 2.x | Medium | #73, #76, #81, #82 |
| picomatch ReDoS/method injection | picomatch 4.x | High/Medium | #74, #83 |

## Jira tickets
VULN-10307, VULN-10608, VULN-10306, VULN-10609

## Test plan
- [x] \`pnpm audit\` shows no picomatch vulnerabilities
- [x] Lockfile only contains picomatch at fixed versions (\`2.3.2\`, \`4.0.4\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)